### PR TITLE
Fixed shape of momentum variable `P`

### DIFF
--- a/code/update_chain_dynamics.m
+++ b/code/update_chain_dynamics.m
@@ -93,7 +93,7 @@ else
     if isempty(c)
         P = 0;
     else
-        P = m * (chain_model.joint(idx_to).v + cross(chain_model.joint(idx_to).w, c));
+        P = m * (chain_model.joint(idx_to).v' + cross(chain_model.joint(idx_to).w, c));
     end
     % Recursive
     childs = chain_model.joint(idx_to).childs;
@@ -116,7 +116,7 @@ else
         L = 0;
     else
         % L = m * (model.node(idx_to).v + cross(model.node(idx_to).w, c));
-        P = m * (chain_model.joint(idx_to).v' + cross(chain_model.joint(idx_to).w', c));
+        P = m * (chain_model.joint(idx_to).v' + cross(chain_model.joint(idx_to).w, c));
         L = cross(c, P) + (chain_model.link(link_idx).I*chain_model.joint(idx_to).w)';
     end
     % Recursive


### PR DESCRIPTION
When calculating the ZMP, chain_model.P returned a size (3,3) matrix
when it should return an array of size 3. The ZMP unit test did not
not catch this because P happend to be all zeros, which made its
effect on subsequent calculations irrelevant.

`update_chain_dynamics.m`
- `chain_model.joint(idx_to).v` was transposed to
match the shape of the cross product that it will be summed with.
- shape of `chain_model.joint(idx_to).w` has been made uniform to remove
unnecessary transposes and since the cross product automatically
identifies the dimension with size 3